### PR TITLE
ci: improve linting coverage for all feature combinations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,8 +40,14 @@ jobs:
     - name: Check formatting
       run: nix develop -c cargo fmt --all --check
     
-    - name: Run linting
-      run: nix develop -c cargo clippy --locked --workspace --all-targets -- --deny warnings --allow deprecated
+    - name: Run linting (default features)
+      run: nix develop -c cargo clippy --locked --workspace --all-targets -- --deny warnings
+    
+    - name: Run linting (async feature)
+      run: nix develop -c cargo clippy --locked --workspace --all-targets --features async -- --deny warnings
+    
+    - name: Run linting (all features)
+      run: nix develop -c cargo clippy --locked --workspace --all-targets --all-features -- --deny warnings
     
     - name: Build default
       run: nix develop -c cargo build --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,13 @@ path = "examples/coldcard_ping.rs"
 
 [workspace]
 members = [".", "hidapi-compat"]
+
+# Workspace-wide lints to ensure consistent code quality
+[workspace.lints.clippy]
+# Deny all warnings in CI
+all = "warn"
+# Additional lints that stable Rust would warn about
+uninlined_format_args = "warn"
+
+[lints]
+workspace = true

--- a/examples/async_hid.rs
+++ b/examples/async_hid.rs
@@ -93,14 +93,11 @@ async fn main() -> Result<()> {
 
     match device.get_feature_report(0x01, &mut feature_buf) {
         Ok(n) => {
-            println!("Got feature report, {} bytes:", n);
+            println!("Got feature report, {n} bytes:");
             println!("Data: {:02x?}", &feature_buf[..n]);
         }
         Err(e) => {
-            println!(
-                "Get feature report failed: {} (this is normal for many devices)",
-                e
-            );
+            println!("Get feature report failed: {e} (this is normal for many devices)");
         }
     }
 
@@ -110,10 +107,7 @@ async fn main() -> Result<()> {
 
     match device.send_feature_report(&feature_data) {
         Ok(()) => println!("Feature report sent successfully"),
-        Err(e) => println!(
-            "Send feature report failed: {} (this is normal for many devices)",
-            e
-        ),
+        Err(e) => println!("Send feature report failed: {e} (this is normal for many devices)"),
     }
 
     println!("\nAsync HID example completed!");

--- a/examples/test_coldcard_async.rs
+++ b/examples/test_coldcard_async.rs
@@ -116,7 +116,6 @@ async fn main() -> Result<()> {
 
     // Spawn 3 async read operations that will timeout
     for i in 0..3 {
-        let mut buf = vec![0u8; 64];
         let handle = tokio::spawn(async move {
             println!("  Task {i} starting...");
             // Simulate read that will timeout

--- a/hidapi-compat/Cargo.toml
+++ b/hidapi-compat/Cargo.toml
@@ -27,3 +27,6 @@ default = []
 linux-static-hidraw = []
 # Feature flag to match hidapi's linux-static-libusb
 linux-static-libusb = []
+
+[lints]
+workspace = true

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,7 +4,7 @@ use hidraw_rs::prelude::*;
 use hidraw_rs::protocol::{frame_packets, unframe_packets};
 
 #[cfg(feature = "async")]
-use hidraw_rs::async_io::{AsyncHidDevice, AsyncHidrawDevice};
+use hidraw_rs::async_io::AsyncHidDevice;
 
 #[test]
 fn test_library_imports() {
@@ -90,7 +90,7 @@ async fn test_async_timeout() {
                 match result {
                     Ok(_) => {}               // Device responded very quickly
                     Err(Error::Timeout) => {} // Expected timeout
-                    Err(e) => panic!("Unexpected error: {:?}", e),
+                    Err(e) => panic!("Unexpected error: {e:?}"),
                 }
             }
         }


### PR DESCRIPTION
## Summary
This PR improves the CI workflow to catch linting errors across all feature combinations, ensuring code quality for feature-gated code.

## Problem
The current workflow only runs `cargo clippy` once with default features, missing potential linting issues in code that's only compiled with specific features enabled (like the `async` feature).

## Solution
Added separate linting steps for:
1. Default features
2. With `async` feature
3. With all features

## Fixes Included
- Fixed unused import in `tests/integration.rs` when `async` feature is enabled
- Removed unused variable in `examples/test_coldcard_async.rs`

## Example of Issues Caught
```rust
// This was only caught when running clippy with --all-features:
use hidraw_rs::async_io::{AsyncHidDevice, AsyncHidrawDevice};
//                                         ^^^^^^^^^^^^^^^^^ unused import

let mut buf = vec\![0u8; 64];  // unused variable
```

## Testing
- [x] All clippy checks pass with default features
- [x] All clippy checks pass with async feature
- [x] All clippy checks pass with all features
- [x] Workflow runs successfully

This ensures better code quality and prevents CI failures from feature-specific linting issues.