### PR TITLE
fix: remove workspace lints from hidapi-compat for vendoring compatibility

### DIFF
--- a/hidapi-compat/Cargo.toml
+++ b/hidapi-compat/Cargo.toml
@@ -28,5 +28,5 @@ linux-static-hidraw = []
 # Feature flag to match hidapi's linux-static-libusb
 linux-static-libusb = []
 
-[lints]
-workspace = true
+# Lints configuration removed to allow vendoring
+# When vendored, workspace.lints cannot be resolved


### PR DESCRIPTION
## Summary
Remove `workspace = true` from the `[lints]` section in hidapi-compat's Cargo.toml to fix vendoring issues.

## Problem
When hidapi-compat is vendored (e.g., by Nix builds), the workspace lints configuration causes build failures because the workspace root cannot be resolved in that context. This prevents projects like cyberkrill from building with Nix.

## Solution
Removed the workspace lints configuration from hidapi-compat. The lints can still be enforced at the workspace level for development, but won't break vendored builds.

## Error this fixes
```
failed to parse manifest at /build/cargo-vendor-dir/hidapi-compat-0.1.0/Cargo.toml
error inheriting lints from workspace root manifest's workspace.lints
failed to find a workspace root
```

## Testing
- [x] Builds successfully when vendored by Nix
- [x] No impact on normal cargo builds

Related to: https://github.com/douglaz/cyberkrill/pull/73