### PR TITLE
chore(deps): upgrade thiserror to v2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -351,18 +351,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["hardware-support", "os::linux-apis"]
 
 [dependencies]
 libc = "0.2"
-thiserror = "1.0"
+thiserror = "2.0"
 rustix = { version = "1.0.8", features = ["fs", "process", "event", "std", "time"] }
 
 # Optional dependencies

--- a/hidapi-compat/Cargo.toml
+++ b/hidapi-compat/Cargo.toml
@@ -16,7 +16,7 @@ provides = "hidapi"
 [dependencies]
 hidraw-rs = { path = ".." }
 libc = "0.2"
-thiserror = "1.0"
+thiserror = "2.0"
 
 [dev-dependencies]
 tokio = { version = "1.47", features = ["full"] }


### PR DESCRIPTION
## Summary
Routine dependency upgrade to keep the codebase current with the latest stable version of thiserror.

## Changes
- Updated thiserror from 1.0 to 2.0 in the main crate
- Updated thiserror from 1.0 to 2.0 in the hidapi-compat crate
- Updated Cargo.lock with new dependency versions

## Technical Details
thiserror v2.0 was released with improvements to error handling and better compiler diagnostics. This is a backward-compatible upgrade with no breaking changes affecting our codebase.

## Test Plan
- [x] `cargo build` passes
- [x] `cargo test` passes  
- [x] `cargo test --all-features` passes
- [x] `cargo clippy` shows no warnings
- [x] `cargo fmt --check` passes
- [x] Pre-push hooks pass