### PR TITLE
chore: update Rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hidraw-rs"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 description = "Rust library for Linux hidraw interface with minimal dependencies"

--- a/examples/coldcard_ping.rs
+++ b/examples/coldcard_ping.rs
@@ -1,6 +1,6 @@
 //! Example: Ping a Coldcard device
 
-use hidraw_rs::coldcard::{ColdcardDevice, COINKITE_VID, COLDCARD_PID};
+use hidraw_rs::coldcard::{COINKITE_VID, COLDCARD_PID, ColdcardDevice};
 use hidraw_rs::prelude::*;
 
 fn main() -> Result<()> {

--- a/examples/device_info_advanced.rs
+++ b/examples/device_info_advanced.rs
@@ -4,7 +4,7 @@
 //! detailed device information including physical location, unique ID, and
 //! report descriptors.
 
-use hidraw_rs::{enumerate, Error, HidDevice, Result};
+use hidraw_rs::{Error, HidDevice, Result, enumerate};
 
 fn print_hex_dump(data: &[u8], max_bytes: usize) {
     let bytes_to_show = data.len().min(max_bytes);

--- a/examples/report_descriptor.rs
+++ b/examples/report_descriptor.rs
@@ -3,7 +3,7 @@
 //! This example shows how to get and interpret HID report descriptors,
 //! which define the structure of data sent to/from HID devices.
 
-use hidraw_rs::{enumerate, Error, HidDevice, Result};
+use hidraw_rs::{Error, HidDevice, Result, enumerate};
 
 /// Basic HID report descriptor item parser
 fn parse_report_descriptor(data: &[u8]) {

--- a/hidapi-compat/Cargo.toml
+++ b/hidapi-compat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hidapi-compat"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"
 description = "hidapi-compatible interface for hidraw-rs"

--- a/src/async_io.rs
+++ b/src/async_io.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides async versions of HID device operations using tokio.
 
-use crate::hidraw::{sys, HidrawDevice};
+use crate::hidraw::{HidrawDevice, sys};
 use crate::{DeviceInfo, Error, Result};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};

--- a/src/device.rs
+++ b/src/device.rs
@@ -140,7 +140,7 @@ impl HidDevice {
 
     /// Internal implementation of read with timeout
     fn read_timeout_impl(&mut self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
-        use rustix::event::{poll, PollFd, PollFlags};
+        use rustix::event::{PollFd, PollFlags, poll};
 
         if buf.is_empty() {
             return Err(Error::InvalidParameter(
@@ -177,7 +177,7 @@ impl HidDevice {
 
     /// Internal implementation of write with timeout
     fn write_timeout_impl(&mut self, data: &[u8], timeout: Duration) -> Result<usize> {
-        use rustix::event::{poll, PollFd, PollFlags};
+        use rustix::event::{PollFd, PollFlags, poll};
 
         // Convert timeout to Timespec for rustix 1.0
         let timeout_spec = rustix::time::Timespec {

--- a/src/hidraw/ioctl_rustix.rs
+++ b/src/hidraw/ioctl_rustix.rs
@@ -9,8 +9,8 @@ use rustix::ioctl::{self, Getter};
 
 // Import the opcode constants and types
 use crate::hidraw::sys::{
-    HidrawReportDescriptor, HIDIOCGRAWINFO, HIDIOCGRAWNAME, HIDIOCGRAWPHYS, HIDIOCGRAWUNIQ,
-    HIDIOCGRDESC, HIDIOCGRDESCSIZE,
+    HIDIOCGRAWINFO, HIDIOCGRAWNAME, HIDIOCGRAWPHYS, HIDIOCGRAWUNIQ, HIDIOCGRDESC, HIDIOCGRDESCSIZE,
+    HidrawReportDescriptor,
 };
 
 /// Get report descriptor size using rustix

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,9 +50,9 @@ pub use hidraw::enumerate;
 
 /// Prelude module for convenient imports
 pub mod prelude {
-    pub use crate::{enumerate, find_devices};
     pub use crate::{DeviceInfo, HidDevice};
     pub use crate::{Error, Result};
+    pub use crate::{enumerate, find_devices};
 }
 
 /// Find devices matching vendor and product ID


### PR DESCRIPTION
## Summary
Update Rust edition from 2021 to 2024 for all crates in the workspace.

## Changes
- Updated `hidraw-rs` crate edition to 2024
- Updated `hidapi-compat` crate edition to 2024
- Applied automatic formatting changes required by edition 2024

## Test Plan
- [x] Project compiles successfully with `cargo check`
- [x] All clippy checks pass
- [x] Code is properly formatted with `cargo fmt`