### PR TITLE
ci: remove Magic Nix Cache from workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,6 @@ jobs:
         extra_nix_config: |
           experimental-features = nix-command flakes
     
-    - name: Setup Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@main
-    
     - name: Cache Cargo registry
       uses: actions/cache@v5
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,9 +46,9 @@ checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"


### PR DESCRIPTION
Removes the `DeterminateSystems/magic-nix-cache-action` step. It has been unreliable in CI (rate-limited local substituter); without it Nix fetches from `cache.nixos.org` directly. The Nix installer and Cargo registry cache are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the build workflow by removing an intermediate caching step, allowing the Nix setup to proceed directly to Cargo registry caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->